### PR TITLE
Fix trailing spaces in style guides

### DIFF
--- a/style_backend.md
+++ b/style_backend.md
@@ -1,4 +1,4 @@
-# style-backend.md
+# Backend Style Guide
 
 ## Purpose
 

--- a/style_common.md
+++ b/style_common.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose
 
-This guide defines universal coding conventions to ensure that an AI agent can generate code that aligns naturally with my personal style.  
+This guide defines universal coding conventions to ensure that an AI agent can generate code that aligns naturally with my personal style.
 It serves as a reference point for consistent implementation regardless of programming language, framework, or project type.
 
 Language-specific and domain-specific rules will be defined separately.
@@ -11,42 +11,42 @@ Language-specific and domain-specific rules will be defined separately.
 
 ## 📁 Project Structure & Design Principles
 
-- **Functional Folder Separation**  
+- **Functional Folder Separation**
   Separate code, data, configurations, and other concerns into logically named directories.
 
-- **Single Responsibility per Module**  
+- **Single Responsibility per Module**
   Each file, class, or module should have one clear responsibility. Avoid mixing unrelated logic in the same unit.
 
-- **Decoupling Entry Points and Logic**  
+- **Decoupling Entry Points and Logic**
   CLI, UI, or HTTP handlers should only invoke logic defined in separate modules. Avoid embedding core logic in entry scripts.
 
 ---
 
 ## 🧠 Naming Conventions
 
-- **Descriptive and Consistent Names**  
+- **Descriptive and Consistent Names**
   Names should clearly reflect purpose or behavior. Avoid cryptic or overly abbreviated names.
 
-- **Consistent Style per Project**  
+- **Consistent Style per Project**
   Use idiomatic naming styles (e.g., camelCase, snake_case, PascalCase) consistently within each project and language.
 
 ---
 
 ## 🔧 Implementation Style
 
-- **Comments Should Capture Intent**  
+- **Comments Should Capture Intent**
   Focus comments on _why_ something is implemented a certain way, not _what_ it does—code should explain the "what".
 
-- **Readable, Modular Logic**  
+- **Readable, Modular Logic**
   Keep nesting shallow. If logic grows complex, split it into helper functions. Functions should aim to be side-effect free.
 
-- **Avoid Hardcoded Constants**  
+- **Avoid Hardcoded Constants**
   Extract configuration values (paths, thresholds, credentials, etc.) into a separate settings or config file.
 
-- **Design for Idempotency**  
+- **Design for Idempotency**
   Code should be safe to re-run without harmful side effects (e.g., repeated file writes, residual state issues).
 
-- **Expressive Layers of Reasoning**  
+- **Expressive Layers of Reasoning**
   Write:
   - **How** in the code itself (expressing logic and flow)
   - **What** in the test code (describing expected behavior)
@@ -57,37 +57,37 @@ Language-specific and domain-specific rules will be defined separately.
 
 ## 🛠️ Error Handling & Reliability
 
-- **Validate Assumptions Up Front**  
+- **Validate Assumptions Up Front**
   When inputs or states have preconditions, check and fail early if violated.
 
-- **Handle Failures Intentionally**  
+- **Handle Failures Intentionally**
   Decide explicitly whether to exit, retry, skip, or fallback—and explain that decision in the code if non-obvious.
 
-- **Prepare the Environment Proactively**  
+- **Prepare the Environment Proactively**
   Ensure directories exist, remove stale files, and prepare all prerequisites before executing logic.
 
 ---
 
 ## 🧾 Documentation Practices
 
-- **README Is a Contract**  
+- **README Is a Contract**
   Every project should have a README with clear: purpose, usage, requirements, setup instructions, and directory structure.
 
-- **Minimal but Strategic Code Comments**  
+- **Minimal but Strategic Code Comments**
   Strive for self-explanatory code, but do leave comments for non-obvious decisions, assumptions, or tradeoffs.
 
 ---
 
 ## 🔁 Git & Workflow Conventions
 
-- **Use Conventional Commits**  
-  Commit messages should follow this pattern:  
+- **Use Conventional Commits**
+  Commit messages should follow this pattern:
   `feat:`, `fix:`, `refactor:`, `chore:`, etc., followed by a short, descriptive message.
 
-- **One Commit = One Logical Change**  
+- **One Commit = One Logical Change**
   Don’t mix unrelated changes in one commit. Keep logic, formatting, and configuration changes separate.
 
-- **Automate Everything Repeatable**  
+- **Automate Everything Repeatable**
   Use formatters, linters, tests, and CI/CD pipelines to ensure consistent builds and reduce manual work.
 
 ---

--- a/style_frontend.md
+++ b/style_frontend.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose
 
-This guide defines a set of frontend development principles derived from my actual coding style.  
+This guide defines a set of frontend development principles derived from my actual coding style.
 Its goal is to ensure that AI agents can generate frontend code that is structurally and stylistically consistent with my own.
 
 ---

--- a/style_go.md
+++ b/style_go.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose
 
-This guide defines Go-specific coding conventions to ensure that AI agents can produce code indistinguishable in style, structure, and intent from my own Go programming habits.  
+This guide defines Go-specific coding conventions to ensure that AI agents can produce code indistinguishable in style, structure, and intent from my own Go programming habits.
 It reflects personal preferences regarding naming, file structure, idiomatic patterns, error handling, and test philosophy.
 
 ---
@@ -83,5 +83,5 @@ It reflects personal preferences regarding naming, file structure, idiomatic pat
 
 ## ⛳ Summary
 
-This guide represents the stylistic and structural norms I follow when writing Go.  
+This guide represents the stylistic and structural norms I follow when writing Go.
 AI agents following this guide should be able to produce Go code that is idiomatic, minimalistic, modular, and highly readable — in line with my personal engineering standards.

--- a/style_java.md
+++ b/style_java.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose
 
-This style guide defines a set of Java development principles that reflect my personal coding style.  
+This style guide defines a set of Java development principles that reflect my personal coding style.
 Its purpose is to enable AI agents to generate Java code that is stylistically consistent with the way I write code, regardless of the framework or domain.
 
 ---

--- a/style_python.md
+++ b/style_python.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Purpose
 
-This guide defines the core Python coding principles I follow, abstracted across domains.  
+This guide defines the core Python coding principles I follow, abstracted across domains.
 It exists to enable AI agents to write Python code that is stylistically and structurally consistent with my personal preferences.
 
 ---
@@ -105,5 +105,5 @@ It exists to enable AI agents to write Python code that is stylistically and str
 
 ## ⛳ Summary
 
-This guide defines my Python coding philosophy: clear, modular, minimal, and explicit.  
+This guide defines my Python coding philosophy: clear, modular, minimal, and explicit.
 AI agents should follow this structure to ensure their output aligns naturally with code I would write.

--- a/style_typescript.md
+++ b/style_typescript.md
@@ -101,7 +101,7 @@ This guide defines shared TypeScript coding conventions to ensure AI agents can 
 
 ## 🧭 Summary
 
-This guide provides the foundation for AI-assisted TypeScript development that mirrors my coding standards:  
+This guide provides the foundation for AI-assisted TypeScript development that mirrors my coding standards:
 **modular, type-safe, explicit, and clean.**
 
 Language-specific quirks and framework preferences should be layered on top of this core foundation as needed.


### PR DESCRIPTION
## Summary
- standardize header in backend style guide
- remove trailing whitespace across all style guides

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e9b7dc160832bbae74a7e76959b0e